### PR TITLE
Фиксы

### DIFF
--- a/loaddrv.bash
+++ b/loaddrv.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+sudo su
+
+/sbin/rmmod tmk1553busb
+
+rm /dev/tmk1553busb0
+rm /dev/tmk1553busb1
+rm /dev/tmk1553busb2
+rm /dev/tmk1553busb3
+rm /dev/tmk1553busb4
+rm /dev/tmk1553busb5
+rm /dev/tmk1553busb6
+rm /dev/tmk1553busb7
+
+/sbin/insmod tmk1553busb.ko 
+
+mknod /dev/tmk1553busb0 c 180 192
+mknod /dev/tmk1553busb1 c 180 193
+mknod /dev/tmk1553busb2 c 180 194
+mknod /dev/tmk1553busb3 c 180 195
+mknod /dev/tmk1553busb4 c 180 196
+mknod /dev/tmk1553busb5 c 180 197
+mknod /dev/tmk1553busb6 c 180 198
+mknod /dev/tmk1553busb7 c 180 199
+
+
+chmod o+rwx /dev/tmk1553busb0
+chmod o+rwx /dev/tmk1553busb1
+chmod o+rwx /dev/tmk1553busb2
+chmod o+rwx /dev/tmk1553busb3
+chmod o+rwx /dev/tmk1553busb4
+chmod o+rwx /dev/tmk1553busb5
+chmod o+rwx /dev/tmk1553busb6
+chmod o+rwx /dev/tmk1553busb7

--- a/make3
+++ b/make3
@@ -1,4 +1,4 @@
 rm -f Makefile
 ln Makefile3 Makefile
 make -C /lib/modules/`uname -r`/build SUBDIRS=$PWD modules
-#rm -v Makefile .*.cmd *.o *.mod.c *.ko
+rm -v Makefile .*.cmd *.o *.mod.c *.symvers #*.ko 

--- a/tmk1553usb.c
+++ b/tmk1553usb.c
@@ -33,6 +33,7 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
 #include <linux/semaphore.h>
+#include <linux/kthread.h>
 #endif
 
 #ifdef CONFIG_DEVFS_FS
@@ -1269,10 +1270,13 @@ nextdev:
   }
 #endif
 #ifdef _LINUX_2_6_
-  kernel_thread((int (*)(void *))kthread_launcher, (void *)dev,
-                CLONE_FILES | CLONE_FS |
-                CLONE_SIGHAND);
+  // kernel_thread((int (*)(void *))kthread_launcher, (void *)dev,
+  //               CLONE_FILES | CLONE_FS |
+  //               CLONE_SIGHAND);
+
+   kthread_run((int (*)(void *))kthread_launcher, (void *)dev, "Elcus_1553usb_thread");
 #endif
+
   down(&dev->startstopth_sem);
 
 #ifdef CONFIG_DEVFS_FS
@@ -1336,9 +1340,13 @@ void kthread_launcher(void *data)
 #ifdef _LINUX_2_6_
   //daemonize("thread_launcher", 0);
 #endif
-  kernel_thread((int (*)(void *))int_thread, (void *)arg,
-                CLONE_FILES | CLONE_FS |
-                CLONE_SIGHAND);
+  // kthread_run((int (*)(void *))kthread_launcher, (void *)dev, "Elcus_1553usb_thread");
+  // kernel_thread((int (*)(void *))int_thread, (void *)arg,
+  //               CLONE_FILES | CLONE_FS |
+  //               CLONE_SIGHAND);
+
+kthread_run((int (*)(void *))int_thread, (void *)arg,
+            "Elcus_1553usb_thread");
 }
 
 void int_thread(struct tmk1553busb * dev)


### PR DESCRIPTION
Add loaddrv file
Fix source code for 3.0 kernel

kernel_thread - deprecated, поэтому закостылял на kthread_run

В итоге стало собираться и выполнять скрипт ./loaddrv.bash  без ошибок в dmesg.
